### PR TITLE
fix(markdown-previewer): #13 hide previewer on Back to Hub

### DIFF
--- a/apps/Yazan_Alqasem/gmarkdownApp.js
+++ b/apps/Yazan_Alqasem/gmarkdownApp.js
@@ -39,6 +39,13 @@ function initPreviewer() {
     return;
   }
 
+  const backButton = document.querySelector('#markdown-app .back-button');
+  if (backButton) {
+    backButton.addEventListener('click', () => {
+      document.getElementById('markdown-app').classList.remove('active');
+    });
+  }
+
   AppUtils.setValue('markdown-input', STARTER_MD);
   renderPreview();
   inEl.addEventListener('input', renderPreview);


### PR DESCRIPTION
Added an event listener to the Back to Hub button to remove the active 
class from the Markdown Previewer container.